### PR TITLE
Feature/password reset

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -6,3 +6,6 @@
 
 <p><%= t('.instruction_2') %></p>
 <p><%= t('.instruction_3') %></p>
+
+<br>
+<p>LessonBoard</p>

--- a/app/views/students/mailer/confirmation_instructions.html.erb
+++ b/app/views/students/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,0 @@
-<p><%= t('.greeting', recipient: @email) %></p>
-
-<p><%= t('.instruction') %></p>
-
-<p><%= link_to t('.action'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/students/mailer/email_changed.html.erb
+++ b/app/views/students/mailer/email_changed.html.erb
@@ -1,7 +1,0 @@
-<p><%= t('.greeting', recipient: @email) %></p>
-
-<% if @resource.try(:unconfirmed_email?) %>
-  <p><%= t('.message_unconfirmed', email: @resource.unconfirmed_email) %></p>
-<% else %>
-  <p><%= t('.message', email: @resource.email) %></p>
-<% end %>

--- a/app/views/students/mailer/password_change.html.erb
+++ b/app/views/students/mailer/password_change.html.erb
@@ -1,3 +1,0 @@
-<p><%= t('.greeting', recipient: @resource.email) %></p>
-
-<p><%= t('.message') %></p>

--- a/app/views/students/mailer/reset_password_instructions.html.erb
+++ b/app/views/students/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,0 @@
-<p><%= t('.greeting', recipient: @resource.email) %></p>
-
-<p><%= t('.instruction') %></p>
-
-<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p><%= t('.instruction_2') %></p>
-<p><%= t('.instruction_3') %></p>

--- a/app/views/students/mailer/unlock_instructions.html.erb
+++ b/app/views/students/mailer/unlock_instructions.html.erb
@@ -1,7 +1,0 @@
-<p><%= t('.greeting', recipient: @resource.email) %></p>
-
-<p><%= t('.message') %></p>
-
-<p><%= t('.instruction') %></p>
-
-<p><%= link_to t('.action'), unlock_url(@resource, unlock_token: @token) %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,16 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: 'localhost',
+    user_name: ENV['MAILER_SENDER'],
+    password: ENV['MAILER_PASSWORD'],
+    authentication: 'plain',
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,6 +73,18 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'http://54.92.39.204/' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.gmail.com',
+    port:                 587,
+    domain:               '54.92.39.204',
+    user_name:            ENV['MAILER_SENDER'],
+    password:             ENV['MAILER_PASSWORD'],
+    authentication:       'plain',
+    enable_starttls_auto: true
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['MAILER_SENDER']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -143,7 +143,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 0.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -110,7 +110,7 @@ ja:
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
       new:
-        forgot_your_password: パスワードを忘れましたか？
+        forgot_your_password: パスワードを忘れた場合はこちら
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
@@ -148,7 +148,7 @@ ja:
         back: 戻る
         didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
         didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
-        forgot_your_password: パスワードを忘れましたか？
+        forgot_your_password: パスワードを忘れた場合はこちら
         sign_in: ログイン
         sign_in_with_provider: "%{provider}でログイン"
         sign_up: アカウント登録
@@ -224,7 +224,7 @@ ja:
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
       new:
-        forgot_your_password: パスワードを忘れましたか？
+        forgot_your_password: パスワードを忘れた場合はこちら
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
@@ -262,7 +262,7 @@ ja:
         back: 戻る
         didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
         didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
-        forgot_your_password: パスワードを忘れましたか？
+        forgot_your_password: パスワードを忘れた場合はこちら
         sign_in: ログイン
         sign_in_with_provider: "%{provider}でログイン"
         sign_up: アカウント登録


### PR DESCRIPTION
This pull request implements the password reset functionality using Devise. 
Users (both instructors and students) can now request a password reset, receive an email with reset instructions, and reset their passwords through a secure link. The following key features have been added:

・Password reset email template standardized for both instructors and students.
・SMTP configuration set up for email delivery.
・Password reset token management and secure link generation.
・All unnecessary custom mailer templates have been removed to streamline the codebase.